### PR TITLE
style: enhance popup UI with MetaMask-like theme

### DIFF
--- a/src/pages/popup/index.css
+++ b/src/pages/popup/index.css
@@ -1,7 +1,82 @@
-body{font-family: ui-sans-serif, system-ui, sans-serif; margin:0;}
-*{box-sizing:border-box}
-.container{width:360px;padding:12px}
-input,select,button,textarea{width:100%;padding:8px;margin:6px 0}
-.row{display:flex;gap:8px}
-.card{border:1px solid #ddd;border-radius:12px;padding:12px;margin:8px 0}
-.small{font-size:12px;color:#666}
+body {
+  margin: 0;
+  font-family: 'Roboto', ui-sans-serif, system-ui, sans-serif;
+  background: linear-gradient(135deg, #f6851b 0%, #fcae1d 100%);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 360px;
+  min-height: 600px;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+.container {
+  width: 360px;
+  padding: 16px;
+  background: #fff;
+  border-radius: 16px;
+  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.1);
+  animation: fadeIn 0.3s ease-out;
+}
+
+input,
+select,
+button,
+textarea {
+  width: 100%;
+  padding: 8px 10px;
+  margin: 8px 0;
+  border-radius: 8px;
+  border: 1px solid #e5e7eb;
+  background: #f9fafb;
+}
+
+.row {
+  display: flex;
+  gap: 8px;
+}
+
+button {
+  background: #f6851b;
+  color: #fff;
+  border: none;
+  cursor: pointer;
+  transition: background 0.2s ease, transform 0.1s ease;
+}
+
+button:hover {
+  background: #fcae1d;
+}
+
+button:active {
+  transform: scale(0.97);
+}
+
+.card {
+  background: #fff;
+  border: none;
+  border-radius: 12px;
+  padding: 12px;
+  margin: 12px 0;
+  box-shadow: 0 1px 5px rgba(0, 0, 0, 0.1);
+  animation: fadeIn 0.4s ease-out;
+}
+
+.small {
+  font-size: 12px;
+  color: #666;
+}
+
+@keyframes fadeIn {
+  from {
+    opacity: 0;
+    transform: translateY(10px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}


### PR DESCRIPTION
## Summary
- restyle popup to mimic MetaMask wallet with gradient background and card shadows
- add button and card animations for a smoother UX

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68974092fce08322b1caf5ef3041af8f